### PR TITLE
Update Umol's method type in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Patrick Bryant, Atharva Kelkar, Andrea Guljas, Cecilia Clementi, Frank Noé
 ![Dynamic JSON Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.semanticscholar.org%2Fgraph%2Fv1%2Fpaper%2F3660911f955c532c186de3b52b03396c851c0aac%3Ffields%3DcitationCount&query=%24.citationCount&label=citation&style=social&labelColor=555555&color=ED8936)
 [![](https://img.shields.io/badge/code-38C26D?style=flat&logo=GitHub&labelColor=555555)](https://github.com/patrickbryant1/Umol)
 ![Stars](https://img.shields.io/github/stars/patrickbryant1/Umol?color=yellow&style=social)
-![](https://img.shields.io/badge/blind-FD6F6F?style=flat&logo=darkreader&labelColor=555555&logocolor=555555) 
+![](https://img.shields.io/badge/known--pocket-FD6F6F?style=flat&logo=darkreader&labelColor=555555&logocolor=555555) 
 
 **PoseBusters: AI-based docking methods fail to generate physically valid poses or generalise to novel sequences**  
 Martin Buttenschoen, Garrett M. Morris, Charlotte M. Deane  


### PR DESCRIPTION
* Per https://github.com/patrickbryant1/Umol/blob/75ce689bde3845792b196db27b7f2ef465d91e68/predict.sh#L4, it seems that Umol was trained with sequence annotations of ground-truth protein binding site residues. As a consequence, this method seems to require known binding pockets to be specified beforehand (to reproduce the results in its paper).